### PR TITLE
Strict Whitelisting by Environment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    strong_arms (0.2.2)
+    strong_arms (0.3.0)
       activesupport (>= 5.1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.0)
+    activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.1, >= 2.1.8)
+      zeitwerk (~> 2.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)

--- a/lib/strong_arms/exception_methods.rb
+++ b/lib/strong_arms/exception_methods.rb
@@ -1,30 +1,46 @@
 module ExceptionMethods
-  def missing_parser_exception
-    raise ArgumentError,
-      "#{name}: No parser specified for input with multiple values."
+  def unhandled_keys_error(args)
+    if unhandled_keys(args).present?
+      keys = unhandled_keys(args)
+      message = "#{name} received unhandled keys: #{keys.join(', ')}."
+
+      raise_or_log_error do
+        StrongArms::UnhandledKeys.new(message)
+      end
+    end
   end
 
-  def unhandled_keys_exception(args)
-    keys = unhandled_keys(args)
-    StrongArms::UnhandledKeys.
-      new("#{name} received unhandled keys: #{keys.join(', ')}.")
+  def empty_arguments_error(args)
+    if args.blank?
+      raise_or_log_error do
+        StrongArms::ValuesMissing.new('No values were passed.')
+      end
+    end
   end
 
-  def empty_arguments_exception
-    ArgumentError.new('No values were passed.')
+  def multiple_attributes_error(attributes)
+    if multiple_attributes?(attributes)
+      message = "#{name} recieved multiple attributes for a single input."
+
+      raise_or_log_error do
+        StrongArms::MultipleAttributesError.new(message)
+      end
+    end
   end
 
-  def missing_parsers_for_multiple_attributes_exception
-    ArgumentError.
-      new("#{name} no parser specified for input with multiple values.")
+  def missing_value_for_required_input_error(name, value, options)
+    if required_input_value_missing?(options, value)
+      raise_or_log_error do
+        StrongArms::RequiredValueMissing.
+          new("No value for required input: #{name}.")
+      end
+    end
   end
 
-  def multiple_attributes_exception
-    ArgumentError.
-      new("#{name} recieved multiple attributes for a single input.")
-  end
-
-  def missing_value_for_required_input_exception(name)
-    ArgumentError.new("No value for required input: #{name}.")
+  def environment_configured_error
+    if StrongArms.configuration.nil?
+      message = "StrongArms must be configured to your environment, see README for getting started."
+      raise StrongArms::ConfigurationMissing.new(message)
+    end
   end
 end

--- a/lib/strong_arms/utilities.rb
+++ b/lib/strong_arms/utilities.rb
@@ -1,4 +1,18 @@
+require 'logger'
+
 module Utilities
+  def raise_or_log_error
+    if StrongArms.env == StrongArms::STRICT_ENV
+      raise yield
+    else
+      error_log.error("[STRONG_ARMS]: #{yield.message}")
+    end
+  end
+
+  def error_log
+    @log ||= Logger.new(STDERR)
+  end
+
   def build_handler(name, options, type:)
     {
       name: name,

--- a/lib/strong_arms/version.rb
+++ b/lib/strong_arms/version.rb
@@ -1,3 +1,3 @@
 module StrongArms
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Implements environment configuration that augments whitelisting behavior for `development` and `production`.

In `development`, StrongArms will unconditionally raise exceptions if it receives key value pairs it does not expect. This is to aid continuous development efforts where incoming request data matches backend system expectations; ensuring client and server to be in sync.

In `production`, StrongArms will log unexpected parameters to STDERR instead of raising an exception and returning 500 status. The expectation here is that your StrongArms have been fine tuned in development and logging is there for catching edge cases that may or may not affect backed behavior.

Not included in this PR -- but planned for future work -- is an explicit `strict` mode for production, called on an individual StrongArms basis. The explicit `strict` mode (production only) would omit unexpected parameters in addition to logging the event; effectively cleaning incoming params.

The behavior described above could very well become a default in production instead of a per StrongArm option.